### PR TITLE
Add profit and experience tracking for Lunar Buckets

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/lunarbuckets/LunarBucketsOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/lunarbuckets/LunarBucketsOverlay.java
@@ -1,10 +1,11 @@
 package net.runelite.client.plugins.microbot.lunarbuckets;
 
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
-import net.runelite.client.plugins.microbot.Microbot;
 
 import javax.inject.Inject;
 import java.awt.*;
@@ -28,6 +29,43 @@ public class LunarBucketsOverlay extends OverlayPanel {
                 .left(Microbot.status)
                 .build());
 
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Total profit:")
+                .right(formatNumber(LunarBucketsScript.casts * LunarBucketsScript.profitPerCast))
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Profit/h:")
+                .right(formatNumber(getProfitPerHour()))
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("XP/h:")
+                .right(formatNumber(getXpPerHour()))
+                .build());
+
         return super.render(graphics);
+    }
+
+    private int getProfitPerHour() {
+        double hours = getElapsedHours();
+        if (hours <= 0) return 0;
+        return (int) (LunarBucketsScript.casts / hours * LunarBucketsScript.profitPerCast);
+    }
+
+    private int getXpPerHour() {
+        double hours = getElapsedHours();
+        if (hours <= 0) return 0;
+        int currentXp = Microbot.getClient().getSkillExperience(Skill.MAGIC);
+        int gained = currentXp - LunarBucketsScript.startMagicXp;
+        return (int) (gained / hours);
+    }
+
+    private double getElapsedHours() {
+        return (System.currentTimeMillis() - LunarBucketsScript.startTime) / 3600000d;
+    }
+
+    private String formatNumber(int value) {
+        return String.format("%,d", value);
     }
 }


### PR DESCRIPTION
## Summary
- Track casts, start XP, and profit per cast for Lunar Buckets
- Display total profit, profit per hour, and Magic XP per hour in the overlay

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b7ce28c6708326abbd01f48a380213